### PR TITLE
Add numerics unit tests for active operators

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Tests CMakeLists.txt
 
 add_subdirectory(fft)
+add_subdirectory(numerics)
 add_subdirectory(python)
-

--- a/tests/numerics/CMakeLists.txt
+++ b/tests/numerics/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(test_nlo_numerics
+  ${CMAKE_CURRENT_LIST_DIR}/test_nlo_numerics.c
+)
+
+target_include_directories(test_nlo_numerics PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_nlo_numerics PRIVATE nlolib)
+
+add_test(NAME test_nlo_numerics COMMAND test_nlo_numerics)

--- a/tests/numerics/test_nlo_numerics.c
+++ b/tests/numerics/test_nlo_numerics.c
@@ -1,0 +1,69 @@
+/**
+ * @file test_nlo_numerics.c
+ * @dir tests/numerics
+ * @brief Unit tests for numerics operators in active use.
+ * @author Wenzel Kinsky
+ * @date 2026-01-29
+ */
+
+#include "fft/nlo_complex.h"
+#include "numerics/math_ops.h"
+#include "numerics/vector_ops.h"
+#include <assert.h>
+
+static void test_nlo_real_factorial(void)
+{
+    assert(nlo_real_factorial(0) == 1);
+    assert(nlo_real_factorial(1) == 1);
+    assert(nlo_real_factorial(2) == 2);
+    assert(nlo_real_factorial(3) == 6);
+    assert(nlo_real_factorial(4) == 24);
+    assert(nlo_real_factorial(6) == 720);
+    assert(nlo_real_factorial(10) == 3628800);
+}
+
+static void test_nlo_complex_fill(void)
+{
+    nlo_complex values[3];
+    nlo_complex fill = nlo_make(1.5, -2.5);
+
+    nlo_complex_fill(values, 3, fill);
+
+    for (size_t i = 0; i < 3; ++i) {
+        assert(NLO_RE(values[i]) == NLO_RE(fill));
+        assert(NLO_IM(values[i]) == NLO_IM(fill));
+    }
+}
+
+static void test_nlo_complex_mul_inplace(void)
+{
+    nlo_complex dst[3] = {
+        nlo_make(1.0, 2.0),
+        nlo_make(-3.0, 4.0),
+        nlo_make(0.5, -1.5)
+    };
+    const nlo_complex src[3] = {
+        nlo_make(2.0, 0.0),
+        nlo_make(0.0, -1.0),
+        nlo_make(-1.0, 2.0)
+    };
+
+    nlo_complex_mul_inplace(dst, src, 3);
+
+    assert(NLO_RE(dst[0]) == 2.0);
+    assert(NLO_IM(dst[0]) == 4.0);
+
+    assert(NLO_RE(dst[1]) == 4.0);
+    assert(NLO_IM(dst[1]) == 3.0);
+
+    assert(NLO_RE(dst[2]) == 2.5);
+    assert(NLO_IM(dst[2]) == 2.5);
+}
+
+int main(void)
+{
+    test_nlo_real_factorial();
+    test_nlo_complex_fill();
+    test_nlo_complex_mul_inplace();
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Add focused unit tests for numerics operators that are actively used to increase coverage and catch regressions. 
- Register the numerics test target with the top-level tests so it builds and runs with the existing test harness.

### Description
- Add `tests/numerics/test_nlo_numerics.c` which exercises `nlo_real_factorial`, `nlo_complex_fill`, and `nlo_complex_mul_inplace` and includes the relevant headers. 
- Add `tests/numerics/CMakeLists.txt` to define the `test_nlo_numerics` executable, link it with `nlolib`, and register the test. 
- Update `tests/CMakeLists.txt` to include the new `numerics` subdirectory so the target is configured and built.

### Testing
- Ran `cmake -S . -B build` and configuration completed successfully. 
- Ran `cmake --build build` and the new `test_nlo_numerics` target was built successfully. 
- Ran `ctest --test-dir build` where `test_nlo_numerics` and `test_nlo_complex` passed but `test_python_bindings` failed due to a missing Python dependency (`ModuleNotFoundError: No module named 'cffi'`). 
- Re-running failed tests with `ctest --test-dir build --rerun-failed --output-on-failure` reproduced the same `cffi`-related failure, confirming the new numerics tests themselves pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cd08a13e08330a4f08d5fd9138a0f)